### PR TITLE
Rename meetings token regen endpoint; update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ client.meetings.list
 client.meetings.fetch(meeting_id: "id")
 client.meetings.create({})
 client.meetings.update(meeting_id: "id", {})
+client.meetings.regenerate_token(meeting_id: "id", participant_id: "id")
 ```
 ### Presets
 ```ruby

--- a/lib/dyte/resources/meetings.rb
+++ b/lib/dyte/resources/meetings.rb
@@ -21,7 +21,7 @@ module Dyte
       Meeting.new put_request("meetings/#{meeting_id}", body: body).body.dig("data", "meeting")
     end
 
-    def token(meeting_id:, participant_id:, **attributes)
+    def regenerate_token(meeting_id:, participant_id:, **attributes)
       Meeting.new post_request("meetings/#{meeting_id}/participants/#{participant_id}/token", body: attributes).body.dig("data")
     end
   end

--- a/test/dyte/resources/meetings_test.rb
+++ b/test/dyte/resources/meetings_test.rb
@@ -50,14 +50,14 @@ class MeetingsResourceTest < Minitest::Test
     assert client.meetings.update(meeting_id: meeting_id, body: body)
   end
 
-  def test_token
+  def test_regenerate_token
     meeting_id = "d8b1a76b-fcd8-413d-8a59-0017e825cfa3"
 
     stub_request(:post, "#{Dyte::Client::BASE_URL}/meetings/#{meeting_id}/participants/1/token")
       .to_return(body: File.new("test/fixtures/meetings/token.json"), headers: {content_type: "application/json"})
 
     client = Dyte::Client.new(api_key: @api_key, organization_id: @organization_id)
-    meeting = client.meetings.token(meeting_id: meeting_id, participant_id: 1)
+    meeting = client.meetings.regenerate_token(meeting_id: meeting_id, participant_id: 1)
     assert_equal Dyte::Meeting, meeting.class
     assert_equal "token_str", meeting.token
   end


### PR DESCRIPTION
Decided this name was more user friendly.