### PR TITLE
add delete participant from meeting endpoint

### DIFF
--- a/lib/dyte/resources/meetings.rb
+++ b/lib/dyte/resources/meetings.rb
@@ -29,5 +29,9 @@ module Dyte
       response = get_request("meetings/#{meeting_id}/participants")
       Collection.from_response(response, type: Participant)
     end
+
+    def delete_participant(meeting_id:, participant_id:)
+      delete_request("meetings/#{meeting_id}/participants/#{participant_id}")
+    end
   end
 end

--- a/test/dyte/resources/meetings_test.rb
+++ b/test/dyte/resources/meetings_test.rb
@@ -72,4 +72,13 @@ class MeetingsResourceTest < Minitest::Test
     assert_equal Dyte::Participant, participants.data.first.class
     assert_equal 30, participants.total_count
   end
+
+  def test_delete_participant
+    stub_request(:delete, "#{Dyte::Client::BASE_URL}/meetings/1/participants/1337")
+      .to_return(body: File.new("test/fixtures/meetings/delete_participant.json"), headers: {content_type: "application/json"})
+
+    client = Dyte::Client.new(api_key: @api_key, organization_id: @organization_id)
+    response = client.meetings.delete_participant(meeting_id: 1, participant_id: 1337)
+    assert_equal 200, response.status
+  end
 end

--- a/test/fixtures/meetings/delete_participant.json
+++ b/test/fixtures/meetings/delete_participant.json
@@ -1,0 +1,9 @@
+{
+  "success": true,
+  "data": {
+    "custom_participant_id": "string",
+    "preset_id": "8384f842-5f4b-4499-a68f-d027dfe5de2e",
+    "created_at": "2019-08-24T14:15:22Z",
+    "updated_at": "2019-08-24T14:15:22Z"
+  }
+}


### PR DESCRIPTION
add the `delete participant` method for meetings.

Api reference: https://docs.dyte.io/api#/operations/delete_meeting_participant

part of #6 